### PR TITLE
Hide sheet sharing tip text

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
             <div id="aumValue" class="value">—</div>
             <div class="updated">Last updated: <span id="lastUpdated">—</span></div>
             <div id="aumError" class="hint err" hidden></div>
-            <div class="hint">Tip: ensure your Sheet is set to <em>Anyone with the link can view</em> or <em>File → Share → Publish to web</em>.</div>
+            <!-- Tip: ensure your Sheet is set to <em>Anyone with the link can view</em> or <em>File → Share → Publish to web</em>. -->
           </div>
         </section>
 


### PR DESCRIPTION
## Summary
- hide the Sheets access tip from the rendered page by converting it into an HTML comment

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d1acbe02948332aa051f48894b30a0