### PR TITLE
Remove tagline from site header

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,6 @@
         <img class="logo" src="satssymbol.png" alt="Long Entropy Capital logo" />
         <div class="brand">
           <h1>Long Entropy Capital</h1>
-          <p class="tag">Digital Capital × Digital Intelligence</p>
         </div>
       </header>
 


### PR DESCRIPTION
## Summary
- remove the "Digital Capital × Digital Intelligence" tagline from the homepage header

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1acebcce88332854a0e098878b399