### PR TITLE
Remove portfolio allocation breakdown note

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,7 +90,6 @@
 
         <section class="card">
           <h2>Portfolio Allocation</h2>
-          <div class="sub">Breakdown adds to 100%</div>
           <div class="pie-wrap"><canvas id="pie"></canvas></div>
         </section>
       </div>


### PR DESCRIPTION
## Summary
- remove the "Breakdown adds to 100%" helper text from the portfolio allocation card

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1ad26a87c833299986920b6da8328