### PR TITLE
Move live status next to AUM heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,8 @@
 
       .card { background: linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01)); border: 1px solid rgba(255,255,255,0.06); border-radius: 18px; padding: 18px; box-shadow: 0 12px 30px rgba(0,0,0,0.30); }
       .card h2 { margin: 2px 0 8px; font-size: 18px; color: #f5f5fb; }
+      .card-head { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; }
+      .card-head h2 { margin: 2px 0 0; }
       .card .sub { color: var(--muted); font-size: 13px; margin-bottom: 10px; }
 
       .aum { display: grid; gap: 8px; }
@@ -78,8 +80,10 @@
 
       <div class="grid">
         <section class="card">
-          <h2>Assets Under Management</h2>
-          <div class="sub">Sourced live from Google&nbsp;Sheets <span id="sheetState" class="chip">Loading…</span></div>
+          <div class="card-head">
+            <h2>Assets Under Management</h2>
+            <span id="sheetState" class="chip">Loading…</span>
+          </div>
           <div class="aum">
             <div id="aumValue" class="value">—</div>
             <div class="updated">Last updated: <span id="lastUpdated">—</span></div>


### PR DESCRIPTION
## Summary
- remove the "Sourced live from Google Sheets" copy from the AUM card
- place the live status chip directly beside the Assets Under Management heading with flex styling

## Testing
- Not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68d1ace00dcc833286f349d73ade697d