### PR TITLE
Use satssymbol as favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Long Entropy Capital</title>
     <meta name="description" content="Long Entropy Capital — AUM and Portfolio Breakdown" />
+    <link rel="icon" type="image/png" href="satssymbol.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- set the site's favicon to reuse the existing satssymbol.png image

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1ae84eb848332b1e500c70cd376c2