### PR TITLE
Copy email CTA to clipboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,8 +58,30 @@
       .chip { font-size: 12px; padding: 4px 8px; border-radius: 999px; background: rgba(255,153,0,0.14); color: var(--accent); border: 1px solid var(--ring); }
 
       footer { margin-top: 36px; color: var(--muted); font-size: 14px; display: flex; gap: 14px; align-items: center; justify-content: space-between; flex-wrap: wrap; }
-      .email { display: inline-flex; align-items: center; gap: 8px; padding: 8px 12px; border: 1px solid rgba(255,255,255,0.06); border-radius: 999px; background: rgba(255,255,255,0.02); }
+      .email {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 12px;
+        border: 1px solid rgba(255,255,255,0.06);
+        border-radius: 999px;
+        background: rgba(255,255,255,0.02);
+        color: var(--text);
+        cursor: pointer;
+        font: inherit;
+        line-height: 1.4;
+        appearance: none;
+        -webkit-appearance: none;
+        transition: color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+      }
       .email:hover { border-color: var(--ring); box-shadow: 0 0 0 6px var(--ring) inset; }
+      .email:focus { outline: 2px solid var(--accent); outline-offset: 2px; }
+      .email:focus:not(:focus-visible) { outline: none; }
+      .email:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+      .email svg { pointer-events: none; flex-shrink: 0; }
+      .email .email-text { transition: color 0.2s ease; }
+      .email.copied { border-color: var(--accent); box-shadow: 0 0 0 6px var(--ring) inset; color: var(--accent); }
+      .email.copied .email-text { color: var(--accent); }
 
       .hint { font-size: 12px; color: var(--muted); }
       .err { color: #fba6a6; }
@@ -107,11 +129,11 @@
 
       <footer>
         <div>
-          <a class="email" href="mailto:hello@longentropycapital.com" aria-label="Email Long Entropy Capital">
+          <button class="email" type="button" data-email="hello@longentropycapital.com" aria-label="Copy email address" title="Copy email address to clipboard">
             <!-- Simple envelope icon -->
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3 5h18v14H3z" stroke="currentColor" stroke-width="1.5"/><path d="m3 7 9 7 9-7" stroke="currentColor" stroke-width="1.5"/></svg>
-            hello@longentropycapital.com
-          </a>
+            <span class="email-text" data-default="hello@longentropycapital.com" aria-live="polite">hello@longentropycapital.com</span>
+          </button>
         </div>
         <div class="hint">© <span id="year"></span> Long Entropy Capital</div>
       </footer>
@@ -199,6 +221,55 @@
         });
       }
 
+      async function copyToClipboard(text) {
+        if (navigator.clipboard?.writeText) {
+          await navigator.clipboard.writeText(text);
+          return;
+        }
+        const textarea = document.createElement('textarea');
+        textarea.value = text;
+        textarea.setAttribute('readonly', '');
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        textarea.style.pointerEvents = 'none';
+        document.body.appendChild(textarea);
+        textarea.select();
+        const ok = document.execCommand('copy');
+        document.body.removeChild(textarea);
+        if (!ok) throw new Error('Copy command was unsuccessful');
+      }
+
+      function setupEmailCopy() {
+        const button = document.querySelector('.email[data-email]');
+        if (!button) return;
+        const email = button.dataset.email;
+        const label = button.querySelector('.email-text');
+        const defaultText = label?.dataset.default || label?.textContent?.trim() || email;
+        let resetTimer;
+        button.addEventListener('click', async (event) => {
+          event.preventDefault();
+          clearTimeout(resetTimer);
+          let success = false;
+          try {
+            await copyToClipboard(email);
+            success = true;
+          } catch (err) {
+            console.error('Failed to copy email', err);
+          }
+          if (success) {
+            button.classList.add('copied');
+            if (label) label.textContent = 'Copied!';
+          } else {
+            button.classList.remove('copied');
+            if (label) label.textContent = 'Unable to copy';
+          }
+          resetTimer = setTimeout(() => {
+            button.classList.remove('copied');
+            if (label) label.textContent = defaultText;
+          }, 2000);
+        });
+      }
+
       function renderPie(rows) {
         const ctx = document.getElementById('pie');
         if (window._pie) window._pie.destroy();
@@ -267,6 +338,7 @@
         }
       }
 
+      setupEmailCopy();
       main();
     </script>
 


### PR DESCRIPTION
## Summary
- replace the mailto email CTA with a button that copies the address to the clipboard and provides visual feedback
- add a clipboard utility with a DOM-based fallback when the async Clipboard API is unavailable
- adjust the email CTA styling to support button focus states and the copied indicator

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d1ad0c8f088332ba5aeb83cb63cd97