### PR TITLE
Add light and dark theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,35 +12,89 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
     <style>
       :root {
-        --bg: #0b0b0d;
-        --card: #121216;
-        --text: #e9e9ef;
-        --muted: #a8a8b3;
+        color-scheme: dark;
+        --bg: #0f1010;
+        --surface: #181a1b;
+        --text: #f7f8f8;
+        --muted: #dfe1e2;
         --accent: #ff9900; /* Bitcoin orange */
         --ring: rgba(255,153,0,0.25);
+        --card-border: rgba(255,255,255,0.06);
+        --table-border: rgba(255,255,255,0.08);
+        --table-row-border: rgba(255,255,255,0.06);
+        --table-row-hover: rgba(255,255,255,0.04);
+        --email-bg: rgba(255,255,255,0.02);
+        --email-border: rgba(255,255,255,0.06);
+        --shadow: 0 12px 30px rgba(0, 0, 0, 0.3);
+        --chip-bg: rgba(255,153,0,0.14);
+        --chip-border: rgba(255,153,0,0.25);
+        --background-image: radial-gradient(1200px 800px at 20% -10%, rgba(25, 25, 35, 0.75), transparent 60%);
+        --tooltip-bg: #1f1f26;
+      }
+
+      :root[data-theme="light"] {
+        color-scheme: light;
+        --bg: #f7f8f8;
+        --surface: #ffffff;
+        --text: #181a1b;
+        --muted: #3d4143;
+        --card-border: rgba(24, 26, 27, 0.08);
+        --table-border: rgba(24, 26, 27, 0.12);
+        --table-row-border: rgba(24, 26, 27, 0.08);
+        --table-row-hover: rgba(24, 26, 27, 0.04);
+        --email-bg: rgba(24, 26, 27, 0.04);
+        --email-border: rgba(24, 26, 27, 0.12);
+        --shadow: 0 12px 30px rgba(15, 16, 16, 0.14);
+        --chip-bg: rgba(255,153,0,0.12);
+        --chip-border: rgba(255,153,0,0.2);
+        --background-image: none;
+        --tooltip-bg: #ffffff;
       }
       * { box-sizing: border-box; }
       html, body { height: 100%; }
       body {
         margin: 0; font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
-        background: radial-gradient(1200px 800px at 20% -10%, #191923, transparent 60%), var(--bg);
+        background-color: var(--bg);
+        background-image: var(--background-image);
         color: var(--text);
         -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility;
+        transition: background-color 0.3s ease, color 0.3s ease;
       }
       a { color: var(--text); text-decoration: none; }
       a:hover { color: var(--accent); }
       .wrap { max-width: 1100px; margin: 0 auto; padding: 28px 20px 80px; }
-      header { display: flex; align-items: center; gap: 16px; }
+      header { display: flex; align-items: center; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
+      .identity { display: flex; align-items: center; gap: 16px; }
       header img.logo { height: 56px; width: auto; filter: drop-shadow(0 2px 8px rgba(0,0,0,0.35)); }
       header .brand { display: flex; flex-direction: column; }
       header h1 { margin: 0; font-size: clamp(26px, 4vw, 36px); letter-spacing: 0.3px; }
       header p.tag { margin: 2px 0 0; color: var(--muted); font-size: 14px; }
+      .theme-toggle {
+        margin-left: auto;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 14px;
+        border: 1px solid var(--card-border);
+        border-radius: 999px;
+        background: var(--surface);
+        color: var(--text);
+        font: inherit;
+        font-size: 14px;
+        cursor: pointer;
+        transition: color 0.2s ease, border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+      }
+      .theme-toggle:hover { border-color: var(--ring); box-shadow: 0 0 0 6px var(--ring) inset; }
+      .theme-toggle:focus { outline: 2px solid var(--accent); outline-offset: 2px; }
+      .theme-toggle:focus:not(:focus-visible) { outline: none; }
+      .theme-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+      .theme-toggle .icon { font-size: 16px; line-height: 1; }
 
       .grid { display: grid; grid-template-columns: 1fr; gap: 20px; margin-top: 28px; }
       @media (min-width: 900px) { .grid { grid-template-columns: 420px 1fr; } }
 
-      .card { background: linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01)); border: 1px solid rgba(255,255,255,0.06); border-radius: 18px; padding: 18px; box-shadow: 0 12px 30px rgba(0,0,0,0.30); }
-      .card h2 { margin: 2px 0 8px; font-size: 18px; color: #f5f5fb; }
+      .card { background: var(--surface); border: 1px solid var(--card-border); border-radius: 18px; padding: 18px; box-shadow: var(--shadow); transition: background-color 0.3s ease, border-color 0.3s ease, color 0.3s ease; }
+      .card h2 { margin: 2px 0 8px; font-size: 18px; color: var(--text); }
       .card-head { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; }
       .card-head h2 { margin: 2px 0 0; }
       .card .sub { color: var(--muted); font-size: 13px; margin-bottom: 10px; }
@@ -53,11 +107,11 @@
       canvas { width: 100% !important; height: 360px !important; }
 
       table { width: 100%; border-collapse: collapse; font-size: 14px; }
-      thead th { text-align: left; color: var(--muted); font-weight: 600; border-bottom: 1px solid rgba(255,255,255,0.08); padding: 10px 8px; }
-      tbody td { padding: 10px 8px; border-bottom: 1px dashed rgba(255,255,255,0.06); }
-      tbody tr:hover { background: rgba(255,255,255,0.02); }
+      thead th { text-align: left; color: var(--muted); font-weight: 600; border-bottom: 1px solid var(--table-border); padding: 10px 8px; }
+      tbody td { padding: 10px 8px; border-bottom: 1px dashed var(--table-row-border); }
+      tbody tr:hover { background: var(--table-row-hover); }
       .right { text-align: right; }
-      .chip { font-size: 12px; padding: 4px 8px; border-radius: 999px; background: rgba(255,153,0,0.14); color: var(--accent); border: 1px solid var(--ring); }
+      .chip { font-size: 12px; padding: 4px 8px; border-radius: 999px; background: var(--chip-bg); color: var(--accent); border: 1px solid var(--chip-border); }
 
       footer { margin-top: 36px; color: var(--muted); font-size: 14px; display: flex; gap: 14px; align-items: center; justify-content: space-between; flex-wrap: wrap; }
       .email {
@@ -65,9 +119,9 @@
         align-items: center;
         gap: 8px;
         padding: 8px 12px;
-        border: 1px solid rgba(255,255,255,0.06);
+        border: 1px solid var(--email-border);
         border-radius: 999px;
-        background: rgba(255,255,255,0.02);
+        background: var(--email-bg);
         color: var(--text);
         cursor: pointer;
         font: inherit;
@@ -93,10 +147,16 @@
     <div class="wrap">
       <header>
         <!-- Place your logo file named 'satssymbol.png' in the same folder as this index.html -->
-        <img class="logo" src="satssymbol.png" alt="Long Entropy Capital logo" />
-        <div class="brand">
-          <h1>Long Entropy Capital</h1>
+        <div class="identity">
+          <img class="logo" src="satssymbol.png" alt="Long Entropy Capital logo" />
+          <div class="brand">
+            <h1>Long Entropy Capital</h1>
+          </div>
         </div>
+        <button class="theme-toggle" type="button" aria-label="Switch to light mode" title="Switch to light mode">
+          <span class="icon" aria-hidden="true">🌙</span>
+          <span class="label">Dark</span>
+        </button>
       </header>
 
       <div class="grid">
@@ -142,6 +202,73 @@
     </div>
 
     <script>
+      const THEME_STORAGE_KEY = 'lec-theme';
+      let lastPortfolioRows = null;
+
+      function getStoredTheme() {
+        try {
+          const value = localStorage.getItem(THEME_STORAGE_KEY);
+          return value === 'light' || value === 'dark' ? value : null;
+        } catch {
+          return null;
+        }
+      }
+
+      function getSystemTheme() {
+        return window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+      }
+
+      function applyTheme(theme, { persist = true } = {}) {
+        const root = document.documentElement;
+        root.dataset.theme = theme;
+        if (persist) {
+          try { localStorage.setItem(THEME_STORAGE_KEY, theme); } catch {}
+        }
+        const button = document.querySelector('.theme-toggle');
+        if (button) {
+          const icon = button.querySelector('.icon');
+          const label = button.querySelector('.label');
+          const isLight = theme === 'light';
+          const nextTheme = isLight ? 'dark' : 'light';
+          if (icon) icon.textContent = isLight ? '🌞' : '🌙';
+          if (label) label.textContent = isLight ? 'Light' : 'Dark';
+          button.setAttribute('aria-label', `Switch to ${nextTheme} mode`);
+          button.setAttribute('title', `Switch to ${nextTheme} mode`);
+        }
+        if (lastPortfolioRows) {
+          renderPie(lastPortfolioRows);
+        }
+      }
+
+      function setupThemeToggle() {
+        const button = document.querySelector('.theme-toggle');
+        if (!button) return;
+        button.addEventListener('click', () => {
+          const current = document.documentElement.dataset.theme === 'light' ? 'light' : 'dark';
+          const next = current === 'light' ? 'dark' : 'light';
+          applyTheme(next);
+        });
+      }
+
+      function watchSystemTheme() {
+        if (!window.matchMedia) return;
+        const media = window.matchMedia('(prefers-color-scheme: light)');
+        const handler = (event) => {
+          if (getStoredTheme()) return;
+          applyTheme(event.matches ? 'light' : 'dark', { persist: false });
+        };
+        if (typeof media.addEventListener === 'function') {
+          media.addEventListener('change', handler);
+        } else if (typeof media.addListener === 'function') {
+          media.addListener(handler);
+        }
+      }
+
+      const storedThemePreference = getStoredTheme();
+      applyTheme(storedThemePreference || getSystemTheme(), { persist: false });
+      setupThemeToggle();
+      watchSystemTheme();
+
       // ========================
       //  CONFIG — update as needed
       // ========================
@@ -273,17 +400,27 @@
       }
 
       function renderPie(rows) {
+        lastPortfolioRows = rows;
         const ctx = document.getElementById('pie');
         if (window._pie) window._pie.destroy();
         const labels = rows.map(r => r.name);
         const data = rows.map(r => +(r.weight.toFixed(2)));
+        const styles = getComputedStyle(document.documentElement);
+        const legendColor = styles.getPropertyValue('--muted').trim() || '#cccccc';
+        const tooltipColor = styles.getPropertyValue('--text').trim() || '#ffffff';
+        const tooltipBg = styles.getPropertyValue('--tooltip-bg').trim() || '#1f1f26';
         window._pie = new Chart(ctx, {
           type: 'pie',
           data: { labels, datasets: [{ data }] },
           options: {
             plugins: {
-              legend: { position: 'bottom', labels: { color: '#e6e6f0' } },
-              tooltip: { callbacks: { label: (ctx) => `${ctx.label}: ${ctx.formattedValue}%` } }
+              legend: { position: 'bottom', labels: { color: legendColor } },
+              tooltip: {
+                backgroundColor: tooltipBg,
+                titleColor: tooltipColor,
+                bodyColor: tooltipColor,
+                callbacks: { label: (ctx) => `${ctx.label}: ${ctx.formattedValue}%` }
+              }
             }
           }
         });


### PR DESCRIPTION
## Summary
- add CSS variables and component styling to support the requested light and dark color palettes
- add a header theme toggle that remembers the user preference and falls back to the system theme
- update the portfolio chart rendering so legend and tooltip colors track the active theme

## Testing
- Manual – loaded the site locally and toggled between light and dark modes

------
https://chatgpt.com/codex/tasks/task_e_68d1b4d3fa008332a786a4d37f583a50